### PR TITLE
Skill shuffle commands

### DIFF
--- a/extplugins/conf/poweradminurt.xml
+++ b/extplugins/conf/poweradminurt.xml
@@ -19,6 +19,10 @@
 		<set name="paexec">100</set>
 
 		<set name="pateams-teams">2</set>
+		<set name="paskuffle-sk">2</set>
+		<set name="paunskuffle-unsk">2</set>
+		<set name="pabalance-bal">2</set>
+		<set name="paminmoves-min">2</set>
 
 		<set name="pamoon-moon">20</set>
 

--- a/extplugins/conf/poweradminurt.xml
+++ b/extplugins/conf/poweradminurt.xml
@@ -19,9 +19,9 @@
 		<set name="paexec">100</set>
 
 		<set name="pateams-teams">2</set>
-		<set name="paskuffle-sk">2</set>
-		<set name="paunskuffle-unsk">2</set>
-		<set name="pabalance-bal">2</set>
+		<set name="paskuffle-sk">20</set>
+		<set name="paunskuffle-unsk">60</set>
+		<set name="pabalance-bal">20</set>
 		<set name="paminmoves-min">2</set>
 
 		<set name="pamoon-moon">20</set>


### PR DESCRIPTION
In an attempt to improve the team balancer we have added skill shuffle commands.
- !paskuffle is intended to replace the implementation of !pashuffle.
- !paminmoves is intended to replace the implementation of !pateams.
- !bal provides diagnostic information on team skill.
- !unskuffle provides a test mechanism to make unfair teams.
