### PR TITLE
b3 1.7 compatibility and minor change

### DIFF
--- a/extplugins/poweradminurt.py
+++ b/extplugins/poweradminurt.py
@@ -101,9 +101,11 @@
 # * add tests
 # 20/09/2010 - 1.5.7 - BlackMamba
 # * fix !pamute - http://www.bigbrotherbot.net/forums/xlr-releases/poweradminurt-1-4-0-for-urban-terror!/msg15296/#msg15296
-#
+# 20/09/2010 - 1.5.8 - SGT
+# * minor fix for b3 1.7 compatibility
+# * fix method onKillTeam
 
-__version__ = '1.5.7'
+__version__ = '1.5.8'
 __author__  = 'xlr8or'
 
 import b3, time, thread, threading, re
@@ -255,8 +257,9 @@ class PoweradminurtPlugin(b3.plugin.Plugin):
     except:
       self._origgear = 0 # allow all weapons
     
+    self.installCrontabs()
+    
     self.debug('Started')
-
 
   def onLoadConfig(self):
     self.LoadNameChecker()
@@ -664,6 +667,8 @@ class PoweradminurtPlugin(b3.plugin.Plugin):
     else:
         self.debug('Rotation Manager is disabled')
 
+
+  def installCrontabs(self):
     # CRONTABS INSTALLATION
     # Cleanup and Create the crontabs
     if self._ncronTab:
@@ -683,8 +688,7 @@ class PoweradminurtPlugin(b3.plugin.Plugin):
       self.console.cron + self._tcronTab
     if self._sinterval > 0:
       self._scronTab = b3.cron.PluginCronTab(self, self.speccheck, 0, '*/%s' % (self._sinterval))
-      self.console.cron + self._scronTab
-
+      self.console.cron + self._scronTab    
 
   def getCmd(self, cmd):
     cmd = 'cmd_%s' % cmd
@@ -771,7 +775,7 @@ class PoweradminurtPlugin(b3.plugin.Plugin):
     killer.var(self, 'kills', 0).value  += 1
     victim.var(self, 'deaths', 0).value += 1
     
-  def onTeamKill(self, killer, victim, points):
+  def onKillTeam(self, killer, victim, points):
     killer.var(self, 'teamkills', 0).value += 1
     
   def dumpEvent(self, event):


### PR DESCRIPTION
- Crontabs setup was moved to startup.
- Method onTeamKill was renamed to onKillTeam, as this was the name used to invoke it.
