### PR TITLE
Please merge version 1.0 of the skill balancer :)

### DIFF
--- a/extplugins/conf/poweradminurt.xml
+++ b/extplugins/conf/poweradminurt.xml
@@ -23,6 +23,7 @@
 		<set name="paunskuffle-unsk">60</set>
 		<set name="pabalance-bal">20</set>
 		<set name="paminmoves-min">2</set>
+		<set name="paswap-swap">20</set>
 
 		<set name="pamoon-moon">20</set>
 

--- a/extplugins/conf/poweradminurt.xml
+++ b/extplugins/conf/poweradminurt.xml
@@ -23,12 +23,12 @@
 		<set name="paunskuffle-unsk">60</set>
 		<set name="pabalance-bal">20</set>
 		<set name="paminmoves-min">2</set>
+		<set name="paautoskuffle-ask">60</set>
 		<set name="paswap-swap">20</set>
 
 		<set name="pamoon-moon">20</set>
 
 		<set name="papublic-public">60</set>
-
 
 		<set name="pamatch-match">60</set>
 		<set name="pagear-gear">60</set>
@@ -92,6 +92,16 @@
 		<set name="autobalance_gametypes">tdm</set>
 		<!-- If a player is locked using !paforceteam, should it be permanent? False releases all locks on gameExit -->
 		<set name="teamLocksPermanent">False</set>
+	</settings>
+
+	<settings name="skillbalancer">
+		<!-- tinterval sets checking intervals in minutes, 0 disables function -->
+		<set name="interval">1</set>
+		<!-- how much difference should we tolerate, unit is average team
+         contribution (kills-deaths) per interval for the top players -->
+		<set name="tcdifference">3</set>
+		<!-- mode: 0 = none, 1 = suggest, 2 = auto minmoves, 3 = auto skuffle -->
+		<set name="mode">1</set>
 	</settings>
 
 	<settings name="votedelay">

--- a/extplugins/conf/poweradminurt.xml
+++ b/extplugins/conf/poweradminurt.xml
@@ -21,8 +21,8 @@
         <set name="pateams-teams">2</set>
         <set name="paskuffle-sk">20</set>
         <set name="paunskuffle-unsk">60</set>
-        <set name="pabalance-bal">20</set>
-        <set name="paminmoves-min">2</set>
+        <set name="paadvise-adv">2</set>
+        <set name="pabalance-bal">2</set>
         <set name="paautoskuffle-ask">60</set>
         <set name="paswap-swap">20</set>
 
@@ -101,8 +101,8 @@
         <!-- how much difference should we tolerate, unit is average team
         contribution (kills-deaths) per interval for the top players -->
         <set name="tcdifference">3</set>
-        <!-- mode: 0 = none, 1 = suggest, 2 = auto minmoves, 3 = auto skuffle -->
-        <set name="mode">1</set>
+        <!-- mode: 0 = none, 1 = advise, 2 = autobalance, 3 = autoskuffle -->
+        <set name="mode">0</set>
     </settings>
 
     <settings name="votedelay">

--- a/extplugins/poweradminurt.py
+++ b/extplugins/poweradminurt.py
@@ -770,7 +770,7 @@ class PoweradminurtPlugin(b3.plugin.Plugin):
       T = min(1.0, age/5.0) # reduce score for players who just joined
       hsratio = T*min(1.0, hs/(1.0+kills)) # hs can be greater than kills
       score = T*kills/(1.0+deaths+teamkills) + T*(kills-deaths-teamkills)/(age+1.0)
-      stats = xlrstats.get_PlayerStats(c)
+      stats = xlrstats and xlrstats.get_PlayerStats(c)
       if stats:
         head = xlrstats.get_PlayerBody(playerid=c.cid, bodypartid=0).kills
         helmet = xlrstats.get_PlayerBody(playerid=c.cid, bodypartid=1).kills
@@ -1009,7 +1009,7 @@ class PoweradminurtPlugin(b3.plugin.Plugin):
         i += 1
     return i
 
-  def cmd_bbswap(self, data, client, cmd=None):
+  def cmd_paswap(self, data, client, cmd=None):
     """\
     <player1> [player2] - Swap two teams for 2 clients. If player2 is not specified, the admin
     using the command is swapped with player1. Doesn't work with spectators (exception for calling admin).
@@ -1043,15 +1043,9 @@ class PoweradminurtPlugin(b3.plugin.Plugin):
       client.message("%s and %s are on the same team! - Nice Try :p" % ((client1.name), client2.name))
       return False
     if client1.team == b3.TEAM_RED:
-      team1 = "blue"
-      team2 = "red"
+      self._move([client1], [client2])  
     else:
-      team1 = "red"
-      team2 = "blue"
-    self.console.write("forceteam %s spectator" % (client1.name))
-    self.console.write("forceteam %s spectator" % (client2.name))	
-    self.console.write("forceteam %s %s" % ((client1.name), team1))
-    self.console.write("forceteam %s %s" % ((client2.name), team2))	
+      self._move([client2], [client1])  
     # No need to send the message twice to the switching admin :-)
     if (client1 != client):
       client1.message("^4You were swapped with %s by the admin." % (client2.name))

--- a/extplugins/poweradminurt.py
+++ b/extplugins/poweradminurt.py
@@ -969,6 +969,12 @@ class PoweradminurtPlugin(b3.plugin.Plugin):
     bestblue = bestred = None # best teams so far when diff > slack
     sbestblue = sbestred = None # new teams so far when diff < slack
     epsilon = 0.0001
+    if abs(len(oldblue)-len(oldred)) > 1:
+      # Teams are unbalanced by count, force both teams two have equal number
+      # of players
+      self.debug('rand: force new teams')
+      blue, red = self._getRandomTeams(clients, checkforced=True)
+      bestdiff = self._getTeamScoreDiff(blue, red, scores)
     for _ in xrange(times):
       blue, red = self._getRandomTeams(clients, checkforced=True)
       m = self._countMoves(oldblue, blue) + self._countMoves(oldred, red)

--- a/extplugins/poweradminurt.py
+++ b/extplugins/poweradminurt.py
@@ -866,8 +866,15 @@ class PoweradminurtPlugin(b3.plugin.Plugin):
   def _countSnipers(self, team):
     n = 0
     for c in team:
-      # Count players with SR8
-      if 'Z' in getattr(c, 'gear', ''):
+      kills = max(0, c.var(self, 'kills', 0).value)
+      deaths = max(0, c.var(self, 'deaths', 0).value)
+      ratio = kills/(1.0+deaths)
+      if ratio < 1.2:
+        # Ignore sniper noobs
+        continue 
+      # Count players with SR8 and PSG1
+      gear = getattr(c, 'gear', '')
+      if 'Z' in gear or 'N' in gear:
         n += 1
     return n
 

--- a/readme-skillbalancer.txt
+++ b/readme-skillbalancer.txt
@@ -1,0 +1,108 @@
+Autobalancer - Skill based
+
+Why?
+====
+In TDM as the classic autobalancer moves players to balance the count of
+players in each team, the skill level of the players is not taken into account.
+This leads to unbalanced ("unfair") teams.
+
+To solve this, we introduce a shuffler that creates teams based on skill;
+skuffle (skill-shuffle).
+
+How is "skill" measured?
+========================
+In the first iteration, the bot used the ratio of kills to deaths as a measure
+of skill. Good players have higher k/d ratios. When a player joins since there
+is no k/d ratio, we used k/d info from XLR stats, if available; if not a
+default average value is provided. XLR info was used only in the first five
+minutes so the players past performance does not bias how the bot looked at
+present performance.   
+
+However, when a player has a spree (either killing or dying rapidly), especially right after they just join causes spikes in the calculation.
+
+In the latest iteration, the bot uses a weighted combination of kill ratio,
+team contribution (TC = kills - deaths), and head shot ratio. (for CTF and Bomb
+modes other relevant stats are used). This combination is time dampened to
+smooth out spikes.
+
+Team balance
+============
+After the skill is measured for all players, they bot shuffles the players into
+red and blue teams till it finds the lowest difference in the sum of skills in
+both teams.
+
+Additionally, it tries to distribute snipers between both teams, because a
+sniper nest in one team can dominate the game (esp. since SR-8 is a one hit
+kill). A sniper is a player carrying a SR-8 or a PSG-1 with a kill ratio more
+than 1.2. This way complete n00bs carrying SR8 are ignored.
+
+Once the bot finds a good new set, the players are moved into new teams. The
+admin who called !sk stays in the same team so it is not jarring.
+
+A full shuffle is not always called for, so there is a balancer (!bal) that
+tries to move not more than 30% of the players. In addition, "forced" players
+are left in place (there was probably a good reason why they were forced :)
+
+If !bal is unable to find a reasonably good team in the 30% it will force a
+full shuffle, though this is very rare in practise.
+
+The !bal command is intended to replace the !teams command. 
+
+Autobalance
+===========
+A long pending request was to automatically balance by skill as the game
+progresses. The bot needs a metric to decide when to run an autobalance
+(thought the teams may be balanced in number the skill level may vary). We
+found that players tend to call for !teams or complain when they are killed
+very quickly and repeatedly. Also, when players are able to kill very rapidly
+and repeatedly they get bored (shooting fish in a barrel).
+
+Additionally, we observed that two l33t players in a team could drastically
+shift the balance by keeping players on the other team busy, enabling the other
+players in their team to get better scores.
+
+So, it is sufficient to look at the top players kill rate in each team to see
+how the game is being perceived.
+
+So, the bot has a sliding window of 2 minutes when it calculate the DATCPM
+(Difference in Average Team Contribution Per Minute). The average of
+kills-deaths for the top players in each team for the last minute is computed,
+and the difference is taken. This difference shows how the game is progressing,
+the higher the difference the more dominant one team is over the other. The bot
+lists several levels of difference (from the code)
+
+absdiff = abs(tcdiff)
+unfair = absdiff > 2.31
+word = None
+if 1 <= absdiff < 2:
+  word = 'stronger'
+if 2 <= absdiff < 3:
+  word = 'dominating'
+if 3 <= absdiff < 4:
+  word = 'overpowering'
+if 4 <= absdiff < 5:
+  word = 'supreme'
+if 5 <= absdiff < 6:
+  word = 'Godlike!'
+if 6 <= absdiff:
+  word = 'probably cheating :P'
+
+By monitoring this difference the bot can take appropriate action. To use this
+the administrator uses the !ask [mode] command, where mode is one of:
+"0-none",
+"1-advise", 
+"2-autobalance", 
+"3-autoskuffle"
+
+mode 1 is the same as calling !adv, which advises on action
+mode 2 uses only the !bal command (which can in turn use !sk if needed)
+mode 3 always shuffles
+
+Our recommendation is to use mode 2.
+
+The !ask command is intended to replace the classic count based autobalancer.
+
+We look forward to comments and feedback on these features.
+
+- tomyl & ZeroBIT
+


### PR DESCRIPTION
Changelog since last merge:
- Renamed !pabalance to !paadvise
- Renamed !paminmoves to !pabalance
- Fixed misc bugs
- Improved sniper splitting. Snipers are sr8 and psg1 players with kill ratio > 1.2.
- Automatic skill-based team balancing depending on team performance (disabled by default for now)
- New command !paautoskuffle to enable skill balancer during game (includes advise mode)
- New command !paswap to swap two players (provided by itsme at bubbleclub.de)
- Experimental support for CTF and Bomb modes
